### PR TITLE
Changed default homepage route from '/categories' to '/tags' for all users

### DIFF
--- a/src/controllers/helpers.js
+++ b/src/controllers/helpers.js
@@ -394,6 +394,10 @@ function checkVisibleChildren(c, cidToAllowed, cidToWatchState, states) {
 helpers.getHomePageRoutes = async function (uid) {
     const routes = [
         {
+            route: 'tags',
+            name: 'Tags',
+        },
+        {
             route: 'categories',
             name: 'Categories',
         },

--- a/src/controllers/helpers.js
+++ b/src/controllers/helpers.js
@@ -19,6 +19,7 @@ const helpers = module.exports;
 
 const relative_path = nconf.get('relative_path');
 const url = nconf.get('url');
+const { assert } = require('console');
 
 helpers.noScriptErrors = async function (req, res, error, httpStatus) {
     if (req.body.noscript !== 'true') {
@@ -391,7 +392,10 @@ function checkVisibleChildren(c, cidToAllowed, cidToWatchState, states) {
     ));
 }
 
+// parameter uid is of type number
+// return type is of type array (object)
 helpers.getHomePageRoutes = async function (uid) {
+    assert(typeof uid == "number")
     const routes = [
         {
             route: 'tags',
@@ -426,6 +430,7 @@ helpers.getHomePageRoutes = async function (uid) {
         uid: uid,
         routes: routes,
     });
+    assert(typeof data.routes == "object")
     return data.routes;
 };
 

--- a/src/controllers/home.js
+++ b/src/controllers/home.js
@@ -7,7 +7,7 @@ const meta = require('../meta');
 const user = require('../user');
 
 function adminHomePageRoute() {
-    return ((meta.config.homePageRoute === 'custom' ? meta.config.homePageCustom : meta.config.homePageRoute) || 'categories').replace(/^\//, '');
+    return ((meta.config.homePageRoute === 'custom' ? meta.config.homePageCustom : meta.config.homePageRoute) || 'tags').replace(/^\//, '');
 }
 
 async function getUserHomeRoute(uid) {

--- a/src/controllers/home.js
+++ b/src/controllers/home.js
@@ -5,15 +5,14 @@ const url = require('url');
 const plugins = require('../plugins');
 const meta = require('../meta');
 const user = require('../user');
+const { assert } = require('console');
 
 
-
+// return type should be string
 function adminHomePageRoute() {
     // assert return type string
     const output = ((meta.config.homePageRoute === 'custom' ? meta.config.homePageCustom : meta.config.homePageRoute) || 'tags').replace(/^\//, '');
-    if (typeof output !== 'string') {
-        throw new TypeError('Parameter "data" must be an string.');
-    }
+    assert(typeof output == "string")
     return output;
 }
 

--- a/src/controllers/home.js
+++ b/src/controllers/home.js
@@ -6,8 +6,15 @@ const plugins = require('../plugins');
 const meta = require('../meta');
 const user = require('../user');
 
+
+
 function adminHomePageRoute() {
-    return ((meta.config.homePageRoute === 'custom' ? meta.config.homePageCustom : meta.config.homePageRoute) || 'tags').replace(/^\//, '');
+    // assert return type string
+    const output = ((meta.config.homePageRoute === 'custom' ? meta.config.homePageCustom : meta.config.homePageRoute) || 'tags').replace(/^\//, '');
+    if (typeof output !== 'string') {
+        throw new TypeError('Parameter "data" must be an string.');
+    }
+    return output;
 }
 
 async function getUserHomeRoute(uid) {


### PR DESCRIPTION
Changed default homepage route from '/categories' to '/tags' for all users. Since we are using tags as "courses", this would allow users to see their "courses" immediately upon login.

Edits src/controllers/home.js and src/controllers/helpers.js

Tested manually through running ./nodebb start and testing with multiple users

Closes #16 