### PR TITLE
Append role type to end of username when editing

### DIFF
--- a/src/user/profile.js
+++ b/src/user/profile.js
@@ -36,7 +36,7 @@ module.exports = function (User) {
 
         await validateData(uid, data);
 
-        const oldData = await User.getUserFields(updateUid, fields);
+        const oldData = await User.getUserFields(updateUid, fields.concat('accounttype'));
         const updateData = {};
         await Promise.all(fields.map(async (field) => {
             if (!(data[field] !== undefined && typeof data[field] === 'string')) {
@@ -48,6 +48,12 @@ module.exports = function (User) {
             if (field === 'email') {
                 return await updateEmail(updateUid, data.email);
             } else if (field === 'username') {
+                // Append "-student" or "-instructor" based on account type
+                if (oldData.accounttype === 'student') {
+                    data.username += '-student';
+                } else if (oldData.accounttype === 'instructor') {
+                    data.username += '-instructor';
+                }
                 return await updateUsername(updateUid, data.username);
             } else if (field === 'fullname') {
                 return await updateFullname(updateUid, data.fullname);


### PR DESCRIPTION
- This pull request adds custom username generation based on the user's role (student or instructor) when editing his or her username. When editing the username, the route is not correct, so logging out and then back in is required.
- resolves #15 by making sure that the username will always have the student role appended to the end