### PR TITLE
Installed the dynamic analysis tool Iroh and tried to run it

### DIFF
--- a/install/package.json
+++ b/install/package.json
@@ -72,6 +72,7 @@
         "html-to-text": "9.0.3",
         "ioredis": "5.2.4",
         "ipaddr.js": "2.0.1",
+        "iroh": "^0.3.0",
         "jquery": "3.6.3",
         "jquery-deserialize": "2.0.0",
         "jquery-form": "4.3.0",

--- a/iroh.js
+++ b/iroh.js
@@ -1,0 +1,40 @@
+// Code generated with help of ChatGPT
+// Import Iroh and its required modules
+import Iroh from 'iroh';
+import 'iroh/dist/iroh.css'; // Import Iroh's CSS for visualization
+
+// Initialize Iroh
+Iroh.init();
+
+// Define a function to run and track your code
+const runCodeWithIroh = () => {
+  // Import the original 'tags.js' file here
+  import('./src/controllers/tags.js')
+    .then(tagsModule => {
+      // Instrument and run your code with Iroh
+      Iroh.enable();
+      tagsModule.getTag();
+      Iroh.disable();
+
+      // Log the execution data
+      const executionData = Iroh.flush();
+      console.log(executionData);
+      
+      // You can save the execution data to a file or visualize it as needed
+    })
+    .catch(error => {
+      console.error('Error loading tags.js:', error);
+    });
+};
+
+// Call the function to run your code with Iroh
+runCodeWithIroh();
+
+// Capture execution data
+const executionData = Iroh.flush();
+
+// Save the execution data to a file
+const fs = require('fs'); // Node.js file system module
+fs.writeFileSync('iroh-execution-data.json', JSON.stringify(executionData, null, 2));
+
+console.log('Execution data saved to iroh-execution-data.json');


### PR DESCRIPTION
Installed the dynamic analysis tool Iroh and tried to run it. Unfortunately did not find instructions on how to run it on the application so tried to run with the help of iroh.js but it turns out that it is giving this error: 

import Iroh from 'iroh';
^^^^^^

SyntaxError: Cannot use import statement outside a module
    at internalCompileFunction (node:internal/vm:73:18)
    at wrapSafe (node:internal/modules/cjs/loader:1178:20)
    at Module._compile (node:internal/modules/cjs/loader:1220:27)
    at Module._extensions..js (node:internal/modules/cjs/loader:1310:10)
    at Module.load (node:internal/modules/cjs/loader:1119:32)
    at Module._load (node:internal/modules/cjs/loader:960:12)
    at Function.executeUserEntryPoint [as runMain] (node:internal/modules/run_main:81:12)
    at node:internal/main/run_main_module:23:47

Node.js v18.17.1
